### PR TITLE
Check if this.props[val] is not undefined

### DIFF
--- a/components/OwlCarousel.jsx
+++ b/components/OwlCarousel.jsx
@@ -88,7 +88,7 @@ class OwlCarousel extends React.Component {
 		const options = {};
 
 		Owl_Carousel_Options.forEach(val => {
-			if (this.props[val]) {
+			if (this.props[val] !== undefined) {
 				options[val] = this.props[val];
 			}
 		});


### PR DESCRIPTION
Otherwise all the boolean options that we can pass won't arrive at owl carousel in case they are set to false because they won't enter the if branch
