### PR TITLE
Removing console log from componentDidUpdate

### DIFF
--- a/components/OwlCarousel.jsx
+++ b/components/OwlCarousel.jsx
@@ -124,7 +124,6 @@ class OwlCarousel extends Component {
 	}
 
     componentDidUpdate() {
-        console.log(this.options);
         this.owlCarousel = $(this.inst);
         this.owlCarousel.owlCarousel(this.options);
     }


### PR DESCRIPTION
The componentDidUpdate method currently console.log's the options, this spams the console a little.