### PR TITLE
Fix React 16 peerDependencies warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "homepage": "https://github.com/seal789ie/react-owl-carousel#readme",
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.22.1",


### PR DESCRIPTION
Fixes #37 

Add `react: ^16.0.0` and `react-dom: ^16.0.0` to existing versions in `peerDependencies`