### PR TITLE
Switch navClass type to array of strings instead of string

### DIFF
--- a/components/OwlCarousel.jsx
+++ b/components/OwlCarousel.jsx
@@ -70,7 +70,7 @@ const Owl_Carousel_Options = {
     stageClass: PropTypes.string,
     stageOuterClass: PropTypes.string,
     navContainerClass: PropTypes.string,
-    navClass: PropTypes.string,
+    navClass: PropTypes.arrayOf(PropTypes.string),
     controlsClass: PropTypes.string,
     dotClass: PropTypes.string,
     dotsClass: PropTypes.string,


### PR DESCRIPTION
Hi,
First of all, this is my very first pull request so I apologize if there's any mistake.
This is the fix for issue #44 where a false alarm was raised when you used an array of strings for `navClass` value (it said you should use a string instead). 